### PR TITLE
Chore: (Docs) Minor docs change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository provides a starter example webhook implementation to handle buil
 
     ```shell
     # Clones the repository
-     degit chromaui/github-webhook-proxy github-webhook-proxy
+     degit chromaui/github-webhook-proxy#main github-webhook-proxy
     ```
 
 1.  **Install the dependencies.**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository provides a starter example webhook implementation to handle buil
 
     ```shell
     # Clones the repository
-     degit chromaui/github-webhook-proxy#main github-webhook-proxy
+    npx degit chromaui/github-webhook-proxy#main github-webhook-proxy
     ```
 
 1.  **Install the dependencies.**


### PR DESCRIPTION
As the master branch is now renamed to main the instructions to clone the repo need a small tweak to safely use the.